### PR TITLE
Add windows support using AV artefact

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ To install the C library, do `Pkg.build`:
 
     julia> Pkg.build("LibSerialPort")
 
-On Unix-like systems, this `libserialport` will be built from source. On Windows a pre-built
-shared library is downloaded and installed into the package directory. Alternatively, follow the [build instructions](http://sigrok.org/wiki/Libserialport) for a system-wide build. If installation through the package system succeeded, then
+On Unix-like systems, this `libserialport` will be built from source. On Windows a pre-built shared library is downloaded and installed into the package directory. Alternatively, follow the [build instructions](http://sigrok.org/wiki/Libserialport) for a system-wide build. If installation through the package system succeeded, then
 
     julia> readdir(joinpath(Pkg.dir("LibSerialPort"), "deps/usr/lib"))
 
@@ -33,3 +32,5 @@ should list your new library. Type
 to get a list of ports detected on your system.
 
 There is currently no documentation, but the examples/ and tests/ directories contain some examples.
+
+Note that on Windows, returning an OS-level port handle is not yet supported.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ To install the C library, do `Pkg.build`:
 
     julia> Pkg.build("LibSerialPort")
 
-(This is only set up fo Unix-like systems. PRs welcome for Windows). Alternatively, follow the [build instructions](http://sigrok.org/wiki/Libserialport) for a system-wide build. If installation through the package system succeeded, then
+On Unix-like systems, this `libserialport` will be built from source. On Windows a pre-built
+shared library is downloaded and installed into the package directory. Alternatively, follow the [build instructions](http://sigrok.org/wiki/Libserialport) for a system-wide build. If installation through the package system succeeded, then
 
     julia> readdir(joinpath(Pkg.dir("LibSerialPort"), "deps/usr/lib"))
 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -7,21 +7,28 @@ const src_uri = "http://sigrok.org/download/source/libserialport/libserialport-"
 
 @BinDeps.setup
 
-libserialport = library_dependency("libserialport", aliases = ["serialport", "libserialport.0"])
+libserialport = library_dependency("libserialport", aliases = ["serialport", "libserialport.0", "libserialport-0"])
 
-provides(Sources, Dict(URI(src_uri) => libserialport))
+if is_windows()
+  version == "0.1.1" || error("Only version 0.1.1 available for Windows")
+  win32_bin_uri = "https://ci.appveyor.com/api/buildjobs/1t0y955tdpvlnl27/artifacts/libserialport-0.1.1.zip"
+  win64_bin_uri = "https://ci.appveyor.com/api/buildjobs/1t0y955tdpvlnl27/artifacts/libserialport-0.1.1.zip"
+  provides(Binaries, URI(Sys.ARCH == :x86_64 ? win64_bin_uri : win32_bin_uri),libserialport, os = :Windows)
+else
+  provides(Sources, Dict(URI(src_uri) => libserialport))
 
-prefix = joinpath(BinDeps.depsdir(libserialport),"usr")
-srcdir = joinpath(BinDeps.depsdir(libserialport),"src", "libserialport-" * version)
+  prefix = joinpath(BinDeps.depsdir(libserialport),"usr")
+  srcdir = joinpath(BinDeps.depsdir(libserialport),"src", "libserialport-" * version)
 
-provides(SimpleBuild,
-    (@build_steps begin
-        GetSources(libserialport)
-        @build_steps begin
-            ChangeDirectory(srcdir)
-            `./configure --prefix=$prefix`
-            `make install`
-        end
-    end), libserialport)
+  provides(SimpleBuild,
+      (@build_steps begin
+          GetSources(libserialport)
+          @build_steps begin
+              ChangeDirectory(srcdir)
+              `./configure --prefix=$prefix`
+              `make install`
+          end
+      end), libserialport)
+end
 
 @BinDeps.install Dict(:libserialport => :libserialport)

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -4,15 +4,14 @@ using BinDeps
 
 const version = "0.1.1"
 const src_uri = "http://sigrok.org/download/source/libserialport/libserialport-" * version * ".tar.gz"
+const win32_bin_uri = "https://github.com/samuelpowell/libserialport/releases/download/" * version * "-av/libserialport-" * version * "-av-i686.zip"
+const win64_bin_uri = "https://github.com/samuelpowell/libserialport/releases/download/" * version * "-av/libserialport-" * version * "-av-x86_64.zip"
 
 @BinDeps.setup
 
 libserialport = library_dependency("libserialport", aliases = ["serialport", "libserialport.0", "libserialport-0"])
 
 if is_windows()
-  version == "0.1.1" || error("Only version 0.1.1 available for Windows")
-  win32_bin_uri = "https://ci.appveyor.com/api/buildjobs/1t0y955tdpvlnl27/artifacts/libserialport-0.1.1.zip"
-  win64_bin_uri = "https://ci.appveyor.com/api/buildjobs/1t0y955tdpvlnl27/artifacts/libserialport-0.1.1.zip"
   provides(Binaries, URI(Sys.ARCH == :x86_64 ? win64_bin_uri : win32_bin_uri),libserialport, os = :Windows)
 else
   provides(Sources, Dict(URI(src_uri) => libserialport))

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,5 +1,3 @@
-# TODO: Windows.
-
 using BinDeps
 
 const version = "0.1.1"

--- a/src/wrap.jl
+++ b/src/wrap.jl
@@ -250,17 +250,19 @@ function sp_get_port_bluetooth_address(port::Port)
     address = (a != C_NULL) ? unsafe_string(a) : ""
 end
 
-# enum sp_return sp_get_port_handle(const struct sp_port *port, void *result_ptr);
-function sp_get_port_handle(port::Port)
-    # For Linux and OS X
-    result = Ref{Cint}(0)
-
-    # TODO: on Windows, result should be Ref{HANDLE}
-
-    ret = ccall((:sp_get_port_handle, libserialport), SPReturn,
-                (Port, Ref{Cint}), port, result)
-    handle_error(ret, loc())
-    result[]
+if is_windows()
+     # TODO: on Windows, result should be Ref{HANDLE}
+    sp_get_port_handle(port::Port) = error("Returning port handle not supported on Windows")
+else    
+    # enum sp_return sp_get_port_handle(const struct sp_port *port, void *result_ptr);
+    function sp_get_port_handle(port::Port)
+        # For Linux and OS X
+        result = Ref{Cint}(0)    
+        ret = ccall((:sp_get_port_handle, libserialport), SPReturn,
+                    (Port, Ref{Cint}), port, result)
+        handle_error(ret, loc())
+        result[]
+    end
 end
 
 # enum sp_return sp_new_config(struct sp_port_config **config_ptr);


### PR DESCRIPTION
The aim is to use AppVeyor to build `libserialport` using MSYS2, then use a binary provider in `BinDeps` to enable Windows support. First attempt seems to work okay.

Todo:

 - [x] Provide stable place for binary download (GitHub release, ~~deployed from AppVeyor~~)
 - [x] Test on 32 and 64 bit builds of Julia on Windows
 - [x] Test that it does not break macOS/Linux
 - [x] Address TODO in `wrap.jl`

This is a slow burner as I don't actually use Windows if I can avoid it. Will ping when ready for review.