### PR TITLE
Automate running tests and examples

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+# Documentation: http://docs.travis-ci.com/user/languages/julia/
+language: julia
+os:
+  - linux
+  - osx
+julia:
+#  - release
+  - 0.7
+  - 1.0
+  - nightly
+## uncomment the following lines to allow failures on nightly julia
+## (tests will run but not make your overall status red)
+matrix:
+  allow_failures:
+  - julia: nightly
+notifications:
+  email: false
+# uncomment the following lines to override the default test script
+#script:
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("LibSerialPort"); Pkg.test("LibSerialPort"; coverage=true)'
+# Documenter auto-deploy                                                                                                                                                                                                                            
+# following `using` instruction is for triggering precompilation                                                                                                                                                                                    

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.com/scls19fr/LibSerialPort.jl.svg?branch=master)](https://travis-ci.com/scls19fr/LibSerialPort.jl)
+
 # LibSerialPort.jl
 
 [libserialport](http://sigrok.org/wiki/Libserialport) is a small, well-documented C library for general-purpose serial port communication. This is a julia wrapper for the library.

--- a/examples/console.jl
+++ b/examples/console.jl
@@ -41,9 +41,9 @@ function serial_loop(sp::SerialPort)
     end
 end
 
-function main()
+function console(args...)
 
-    if length(ARGS) != 2
+    if length(args) != 2
         println("Usage: $(basename(@__FILE__)) port baudrate")
         println("Available ports:")
         list_ports()
@@ -51,9 +51,9 @@ function main()
     end
 
     # Open a serial connection to the microcontroller
-    mcu = open(ARGS[1], parse(Int, ARGS[2]))
+    mcu = open(args[1], parse(Int, args[2]))
 
     serial_loop(mcu)
 end
 
-main()
+console(ARGS...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,24 @@
+#=
+Run test locally using
+$ julia test/runtest.jl /dev/ttyXYZ
+
+/dev/ttyXYZ can be:
+/dev/ttyS0  (for Travis)
+/dev/ttyS4
+/dev/ttyUSB0
+=#
+
 using LibSerialPort
 using Test
 
-@testset "LibSerialPort" begin
-    port = "/dev/ttyS4"
 
+if length(ARGS) == 0
+    port = "/dev/ttyS0"  # /dev/ttyS4 /dev/ttyUSB0
+else
+    port = ARGS[1]
+end
+
+@testset "LibSerialPort" begin
     @testset "Low level API" begin
         include("test-low-level-api.jl")
         test_low_level_api()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,25 @@
+using LibSerialPort
+using Test
+
+@testset "LibSerialPort" begin
+    port = "/dev/ttyS4"
+
+    @testset "Low level API" begin
+        include("test-low-level-api.jl")
+        test_low_level_api()
+        test_low_level_api(port)
+    end
+
+
+    @testset "High level API" begin
+        include("test-high-level-api.jl")
+        test_high_level_api()
+        test_high_level_api(port)
+    end
+
+    @testset "Examples" begin
+        include("../examples/console.jl")
+        console()
+        console(port)
+    end
+end

--- a/test/test-high-level-api.jl
+++ b/test/test-high-level-api.jl
@@ -1,6 +1,7 @@
 
 using LibSerialPort
 
+
 function test_nonblocking_serial_loopback(sp::SerialPort)
 
     println("\n[TEST] Read any incoming data for ~1 second...")
@@ -66,16 +67,16 @@ function test_readline(sp::SerialPort)
     flush(sp, buffer=SP_BUF_BOTH)
 end
 
-function main()
+function test_high_level_api(args...)
 
-    if length(ARGS) != 2
+    if length(args) != 2
         println("Usage: $(basename(@__FILE__)) port baudrate")
         println("Available ports:")
         list_ports()
         return
     end
 
-    sp = open(ARGS[1], parse(Int, ARGS[2]))
+    sp = open(args[1], parse(Int, args[2]))
 
     print_port_metadata(sp)
     print_port_settings(sp)
@@ -86,4 +87,4 @@ function main()
     close(sp)
 end
 
-main()
+test_high_level_api(ARGS...)

--- a/test/test-low-level-api.jl
+++ b/test/test-low-level-api.jl
@@ -181,9 +181,9 @@ and one stop bit. The baud rate is overridden on the command line with a
 second argument. Hardware and software flow control measures are disabled by
 default.
 """
-function main()
+function test_low_level_api(args...)
 
-    nargs = length(ARGS)
+    nargs = length(args)
     if nargs == 0
         println("Usage: $(basename(@__FILE__)) port [baudrate]")
         println("Available ports:")
@@ -191,8 +191,8 @@ function main()
         return
     end
 
-    port = sp_get_port_by_name(ARGS[1]) # e.g. "/dev/cu.wchusbserial1410"
-    baudrate = nargs >= 2 ? parse(Int, ARGS[2]) : 9600
+    port = sp_get_port_by_name(args[1]) # e.g. "/dev/cu.wchusbserial1410"
+    baudrate = nargs >= 2 ? parse(Int, args[2]) : 9600
 
     print_version()
     list_ports()
@@ -212,4 +212,4 @@ function main()
     sp_free_port(port)
 end
 
-main()
+test_low_level_api(ARGS...)


### PR DESCRIPTION
Helps #16 

CI jobs for Linux and Julia 0.7 / Julia 1.0 are both failing.
But that's not serious.

With Julia 0.7 we can noticed in https://travis-ci.com/scls19fr/LibSerialPort.jl/jobs/140541979
that LibSerialPort is building properly but tests are failing because of 

```
  Got exception ErrorException("From /home/travis/build/scls19fr/LibSerialPort.jl/src/wrap.jl: 124:\n\nlibserialport returned SP_ERR_FAIL - Host OS reported a failure.") outside of a @test
  From /home/travis/build/scls19fr/LibSerialPort.jl/src/wrap.jl: 124:
```

With Julia 1.0 it's not building correctly... and that's exactly what is expected since #17 is not fixed.
see https://travis-ci.com/scls19fr/LibSerialPort.jl/jobs/140541980
We can see https://travis-ci.com/scls19fr/LibSerialPort.jl/jobs/140541980#L530 the error I reported previously

```
ERROR: LoadError: LoadError: UndefVarError: readstring not defined
```
