### PR TITLE
Don't extend Base.open

### DIFF
--- a/src/LibSerialPort.jl
+++ b/src/LibSerialPort.jl
@@ -96,7 +96,7 @@ export
     SP_XONXOFF_OUT,
     SP_XONXOFF_INOUT
 
-import Base: isopen, open, close, write, unsafe_write, flush,
+import Base: isopen, close, write, unsafe_write, flush,
     read, unsafe_read, bytesavailable, eof
 
 


### PR DESCRIPTION
This is a trivial fix for #79. It simply removes `open` from the list of imports. This is a breaking change but prevents type piracy.